### PR TITLE
Fixed Typos in Chapters

### DIFF
--- a/content/abstract-algebra/en/abstract-algebra.md
+++ b/content/abstract-algebra/en/abstract-algebra.md
@@ -6,7 +6,7 @@ If we have sets and a binary operator on that set, we can categorize those sets 
 
 Mathematicians have a word for every possible kind of behavior of the binary operator on the set. As applied programmers, we care about the Group (from Group Theory) in particular, but let’s work our way there incrementally. The group is just one type of animal in this large zoo. So rather than study the group in isolation, let’s study the group in its larger context of related algebraic structures (i.e. sets with a binary operator).
 
-Abstract algebra is a massive field, but our objective here is to clearly understand what a *Group* is because that is used everwhere in Zero Knowledge Proofs. We could just give a definition right now:
+Abstract algebra is a massive field, but our objective here is to clearly understand what a *Group* is because that is used everywhere in Zero Knowledge Proofs. We could just give a definition right now:
 
 *A Group is a set with a binary operator that is closed, associative, has an identity element, and where each element has an inverse.*
 
@@ -109,7 +109,7 @@ If it feels like we "hacked" the identity element in, we did.
 
 We’ll see later that elliptic curves use a trick like this and include a special point called the “point at infinity” to stay consistent with the algebraic laws. The point is we need to be very clear what our identity element is if we say a set is a Monoid over some binary operator.
 
-As another example, we could say our set is all positive integers under addition, with the additional element $\text{mug}$. We define $\text{mug} + x = x$ and $x + \text{mug} = x$. As the architects of the systems, we are allow to make our set consist of whatever we like, and the binary operator behave however we like. However, the binary operator must be closed, associative, and the set must have an identity element for that algebraic data structure to be a Monoid.
+As another example, we could say our set is all positive integers under addition, with the additional element $\text{mug}$. We define $\text{mug} + x = x$ and $x + \text{mug} = x$. As the architects of the systems, we are allowed to make our set consist of whatever we like, and the binary operator behave however we like. However, the binary operator must be closed, associative, and the set must have an identity element for that algebraic data structure to be a Monoid.
 
 If we restrict the domain to be all subsets of $\set{0,1,2,3,4,5}$, then intersection clearly becomes a Monoid because the identity element would be $\set{0,1,2,3,4,5}$, as any set of integers you intersect with it will produce the other set, i.e. $A ∩ \set{0,1,2,3,4,5} = A$. For example, $\set{1,3,4} ∩ \set{0,1,2,3,4,5} = \set{1,3,4}$.
 
@@ -175,7 +175,7 @@ The technicality is we don't normally say "addition is abelian" but "the group i
 Let’s tie this all back to what we learned at the beginning. Magmas, Semigroups, Monoids, and Groups are all sets that have a closed binary operator. A binary operator is just a map from all the ordered pairs of the set’s Cartesian product with itself back to itself.
 
 
-Groups are a subset of Monois, Monoids are a subset of Semigroups, Semigroups are a subset of Magmas, and Magmas are a subset of sets in general. Every Group is also a Magma or a set, but a Magma is not necessarily a Group.
+Groups are a subset of Monoids, Monoids are a subset of Semigroups, Semigroups are a subset of Magmas, and Magmas are a subset of sets in general. Every Group is also a Magma or a set, but a Magma is not necessarily a Group.
 
 “Sets” are easy to conceptualize, but when we start talking about groups and other algebraic structures, it’s easy to start getting lost. Groups are very important in our study of cryptography. Just remember:
 

--- a/content/bilinear-pairing/en/bilinear-pairing.md
+++ b/content/bilinear-pairing/en/bilinear-pairing.md
@@ -1,6 +1,6 @@
 # Bilinear Pairings in Python, Solidity, and the EVM
 
-Sometimes also called bilinear mappings, bilinear parings allow us to take three numbers, $a$, $b$, and $c$, where $ab = c$, encrypt them to become $E(a)$, $E(b)$, $E(c)$, where $E$ is an encryption function, then send the two encrypted values to a verifier who can verify $E(a)E(b) = E(c)$ but not know the original values. We can use bilinear pairings to prove that a 3rd number is the product of the first two without knowing the first two original numbers.
+Sometimes also called bilinear mappings, bilinear pairings allow us to take three numbers, $a$, $b$, and $c$, where $ab = c$, encrypt them to become $E(a)$, $E(b)$, $E(c)$, where $E$ is an encryption function, then send the two encrypted values to a verifier who can verify $E(a)E(b) = E(c)$ but not know the original values. We can use bilinear pairings to prove that a 3rd number is the product of the first two without knowing the first two original numbers.
 
 We will explain bilinear pairings at a high level and provide some examples in Python.
 
@@ -78,7 +78,7 @@ However, despite it being a black box, we still know a lot about the properties 
 - Because the group is cyclic, it has a generator.
 - Because the group is cyclic and finite, then finite cyclic groups are homomorphic to $G_T$. That is, we have some way to homomorphically map elements in a finite field to elements in $G_T$.
 
-Because the group is cyclic, we have a notion of $G_T$, $2G_T$, $3G_T$, and so fourth. The binary operator of $G_T$ is roughly what we would call "multiplication" so $8G_T = 2G_T * 4G_T$.
+Because the group is cyclic, we have a notion of $G_T$, $2G_T$, $3G_T$, and so forth. The binary operator of $G_T$ is roughly what we would call "multiplication" so $8G_T = 2G_T * 4G_T$.
 
 If you really want to know what $G_T$ "looks like", it's a 12-Dimensional object. The identity element isn't so scary looking however:
 
@@ -333,7 +333,7 @@ and zero otherwise.
 This might be a bit of a head-scratcher at first! This seems to imply that the precompile is taking the discrete log of each of the points, which is accepted to be infeasible in general. Furthermore, why doesn’t it behave like pairing from the earlier Python examples? The earlier examples returned an element in $G_T$, but this precompile returns a boolean.
 
 #### Justification for EIP 197 design decision
-The first problem is that elements in $G_T$ are large, specically, they 12-dimensional objects. 
+The first problem is that elements in $G_T$ are large, specifically, they 12-dimensional objects. 
 
 This will take up a lot of space in memory leading to larger gas costs. Also, because of how most ZK verification algorithms work (this is outside the scope of this article), we generally don’t check the value of the output of a pairing, but only that it is equal to other pairings. Specifically, the final step in [Groth16](https://www.rareskills.io/post/groth16) (the zero knowledge algorithm used by tornado cash) looks like the following
 

--- a/content/elliptic-curve-addition/en/elliptic-curve-addition.md
+++ b/content/elliptic-curve-addition/en/elliptic-curve-addition.md
@@ -198,7 +198,7 @@ Let’s see that elliptic curves meet the group property.
 A binary operator must accept every possible pair from the set. What if the pair is the same element, i.e. A ⊕ A?
 
 ## Point multiplication: adding a point with itself
-Let’s think of this in limit terms. Adding a point to itself is like bringing two points infintesimally close to each other until they become the same point. When this convergence happens, the slope of the line will lie tangent to the curve.
+Let’s think of this in limit terms. Adding a point to itself is like bringing two points infinitesimally close to each other until they become the same point. When this convergence happens, the slope of the line will lie tangent to the curve.
 
 So adding a point to itself is simply taking the derivative at that point, getting the intersection, then flipping the $y$ axis.
 

--- a/content/elliptic-curves-finite-fields/en/elliptic-curves-finite-fields.md
+++ b/content/elliptic-curves-finite-fields/en/elliptic-curves-finite-fields.md
@@ -81,13 +81,13 @@ To solve the equation above, and determine which $(x, y)$ points are on the curv
 ### Modular square roots
 We use the [Tonelli Shanks Algorithm](https://en.wikipedia.org/wiki/Tonelli%E2%80%93Shanks_algorithm) to compute modular square roots. You can read up on how the algorithm works if you are curious, but for now you can treat it as a black box that computes the mathematical square root of a field element over a modulus, or lets you know if the square root does not exist.
 
-For example, the square root of 5 modulo 11 is 4 $(4 \times 4 \mod 11 = 5)$, but there is no square root of 6 modulo 11. (The reader is encourage to discover this is true via brute force).
+For example, the square root of 5 modulo 11 is 4 $(4 \times 4 \mod 11 = 5)$, but there is no square root of 6 modulo 11. (The reader is encouraged to discover this is true via brute force).
 
 Square roots often have two solutions, a positive and a negative one. Although we don’t have numbers with a negative sign in a finite field, we still have a notion of "negative numbers" in the sense of having an inverse.
 
 You can find code online to implement the algorithm described above, but to avoid putting large chunks of code in this tutorial, we will install a Python library instead.
 
-For example, the square root of 5 modulo 11 is 4 (4 × 4 mod 11 = 5), but there is no square root of 6 modulo 11. (The reader is encourage to discover this is true via brute force).
+For example, the square root of 5 modulo 11 is 4 (4 × 4 mod 11 = 5), but there is no square root of 6 modulo 11. (The reader is encouraged to discover this is true via brute force).
 
 Square roots have two solutions, a positive and a negative one. Although we don’t have numbers with a negative sign in a finite field, we still have a notion of “negative numbers” in the sense of having an inverse.
 


### PR DESCRIPTION
Fixed typos in the following chapters:
- `abstract-algebra`
- `bilinear-pairings`
- `elliptic-curve-addition`
- `elliptic-curves-finite-fields`