### PR TITLE
Elaborated and fixed some issues in the Evaluating and Quadratic Arithmetic Program on a Trusted Setup

### DIFF
--- a/content/elliptic-curve-qap/en/elliptic-curve-qap.md
+++ b/content/elliptic-curve-qap/en/elliptic-curve-qap.md
@@ -24,7 +24,7 @@ $$\sum_{i=1}^4a_iu_i(x)\sum_{i=1}^4a_iv_i(x) = \sum_{i=1}^4a_iw_i(x) + h(x)t(x)$
 ## Notation and Preliminaries
 We refer to the generators elliptic curve points in the groups $\mathbb{G}_1$ and $\mathbb{G}_2$ as $G_1$ and $G_2$ respectively. An element in $\mathbb{G}_1$ is denoted as $[X]_1$. An element in $\mathbb{G}_2$ is denoted as $[X]_2$. Where there might be ambiguity with the subscripts referring to indices in a list, we say $X \in \mathbb{G}_1$ or $X \in \mathbb{G}_2$. An [elliptic curve pairing](https://www.rareskills.io/post/bilinear-pairing) between two points is denoted as $[X]_1 \bullet [Y]_2$.
 
-Let $\mathbf{L}_{(*,j)}$ be the $j$-th column of $\mathbf{L}$. In our example, the rows will be $(1,2,3)$ and the columns $(1,2,3,4)$. Let $\mathcal{L}(\mathbf{L}_{(*,j)})$ be the polynomial obtained from running Lagrange interpolation on the $j$-th column of $\mathbf{L}$ using the $x$ values $(1,2,3,4)$ and the $y$ values being the values of the $j$-th column.
+Let $\mathbf{L}_{(*,j)}$ be the $j$-th column of $\mathbf{L}$. In our example, the rows will be $(1,2,3)$ and the columns $(1,2,3,4)$. Let $\mathcal{L}(\mathbf{L}_{(*,j)})$ be the polynomial obtained from running Lagrange interpolation on the $j$-th column of $\mathbf{L}$ using the $x$ values $(1,2,3)$ and the $y$ values being the values of the $j$-th column.
 
 Since we have 4 columns, we obtain four polynomials from $\mathbf{L}$
 

--- a/content/elliptic-curve-qap/en/elliptic-curve-qap.md
+++ b/content/elliptic-curve-qap/en/elliptic-curve-qap.md
@@ -72,7 +72,11 @@ $$
 h(x)=\frac{\sum_{i=1}^4a_iu_i(x)\sum_{i=1}^4a_iv_i(x) - \sum_{i=1}^4a_iw_i(x)}{t(x)}
 $$
 
-Note that $h(x)$ can have at most degree 1 in our example. The highest degree $\sum_{i=1}^4a_iu_i(x)\sum_{i=1}^4a_iv_i(x)$ can have is 4 (degree 2 times degree 2), the lowest degree $\sum_{i=1}^4a_iw_i(x)$ can have is zero (a constant). Since $t(x)$ has degree 3, the highest degree the ratio can have is 1. In general, the highest degree $h(x)$ can have is $n - 2$, where $n$ is the number of rows in the R1CS.
+Note that $h(x)$ can have at most degree 1 in our example. The highest degree $\sum_{i=1}^4a_iu_i(x)\sum_{i=1}^4a_iv_i(x)$ can have is 4 (degree 2 times degree 2), the lowest degree $\sum_{i=1}^4a_iw_i(x)$ can have is zero (a constant). Since $t(x)$ has degree 3, the highest degree the ratio can have is 1. In general, the highest degree $h(x)$ can have is $n - 2$, where $n$ is the number of rows in the R1CS. This is due to the fact that if we have $n$ rows i.e. $n$ number of verification steps then we would be having $u_i(x)$ to be of degree = $n - 1$ and similarly for $v_i(x)$ to be of degree = $n - 1$. On the other hand $t(x)$ is of degree = $n$ as per the definition and lowest degree of $w_i(x)$ is $0$. In that case, $deg(h(x))_{max}$ would be
+
+$$
+(n - 1) + (n - 1) - 0 - n = n - 2
+$$
 
 ## Expanding the terms
 

--- a/content/groth16/en/groth16.md
+++ b/content/groth16/en/groth16.md
@@ -29,7 +29,7 @@ t(x) = (x - 1)(x - 2)\dots(x - n)
 $$
 and
 $$
-h(x) = \frac{\sum_{i=1}^m a_iu_i(x)\sum_{i=1}^m a_iv_i(x) - \sum_{i=1}^n a_iw_i(x)}{t(x)}
+h(x) = \frac{\sum_{i=1}^m a_iu_i(x)\sum_{i=1}^m a_iv_i(x) - \sum_{i=1}^m a_iw_i(x)}{t(x)}
 $$
 
 If a third party creates a structured reference string (srs) via a powers of tau ceremony, then the prover can evaluate sum terms (the $\sum a_if_i(x)$ terms) in the QAP at a hidden point $\tau$. Let the structured reference strings be computed as follows:
@@ -61,8 +61,8 @@ The prover can evaluate their QAP on the trusted setup by computing:
 $$
 \begin{align*}
 [A]_1 &= \sum_{i=1}^m a_iu_i(\tau)\\
-[B]_2 &= \sum_{i=1}^ma_iv_i(\tau)\\
-[C]_1 &= \sum_{i=1}^n a_iw_i(\tau) + h(\tau)t(\tau)
+[B]_2 &= \sum_{i=1}^m a_iv_i(\tau)\\
+[C]_1 &= \sum_{i=1}^m a_iw_i(\tau) + h(\tau)t(\tau)
 \end{align*}
 $$
 
@@ -153,7 +153,7 @@ What we referred to as $[D]_{12}$ is simply $[\alpha]_1 \bullet [\beta]_2$.
 ### Re-deriving the proving and verification formulas
 To make the verification formula $[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1\bullet[\beta]_2 + [C]_1\bullet G_2$ "solveable", we need to alter our QAP formula to incorporate $\alpha$ and $\beta$.
 
-$$\sum_{i=1}^m a_iu_i(x)\sum_{i=1}^m a_iv_i(x) = \sum_{i=1}^n a_iw_i(x) + h(x)t(x)$$
+$$\sum_{i=1}^m a_iu_i(x)\sum_{i=1}^m a_iv_i(x) = \sum_{i=1}^m a_iw_i(x) + h(x)t(x)$$
 
 Now consider what happens if we introduce terms $\theta$ and $\eta$ to the left hand side of the equation:
 
@@ -163,11 +163,11 @@ $$=\boxed{\theta\eta} + \boxed{\theta}\sum_{i=1}^m a_iv_i(x) + \boxed{\eta}\sum_
 We can substitute the rightmost terms using the original QAP definition:
 $$=\theta\eta + \theta\sum_{i=1}^m a_iv_i(x) + \eta\sum_{i=1}^m a_iu_i(x) + \boxed{\sum_{i=1}^m a_iu_i(x)\sum_{i=1}^m a_iv_i(x)}$$
 
-$$=\theta\eta + \theta\sum_{i=1}^m a_iv_i(x) + \eta\sum_{i=1}^m a_iu_i(x) + \boxed{\sum_{i=1}^n a_iw_i(x) + h(x)t(x)}$$
+$$=\theta\eta + \theta\sum_{i=1}^m a_iv_i(x) + \eta\sum_{i=1}^m a_iu_i(x) + \boxed{\sum_{i=1}^m a_iw_i(x) + h(x)t(x)}$$
 
 Now we can introduce an "expanded" QAP with the following definition:
 
-$$(\theta+\sum_{i=1}^m u_i(x))(\eta +\sum_{i=1}^m v_i(x)) =\theta\eta + \theta\sum_{i=1}^m a_iv_i(x) + \eta\sum_{i=1}^m a_iu_i(x) + \sum_{i=1}^n a_iw_i(x) + h(x)t(x)$$
+$$(\theta+\sum_{i=1}^m u_i(x))(\eta +\sum_{i=1}^m v_i(x)) =\theta\eta + \theta\sum_{i=1}^m a_iv_i(x) + \eta\sum_{i=1}^m a_iu_i(x) + \sum_{i=1}^m a_iw_i(x) + h(x)t(x)$$
 
 As a sneak peak to where we are going, if we replace $\theta$ with $[\alpha]_1$ and $\eta$ with $[\beta]_2$, we get updated verification formula from earlier:
 
@@ -175,7 +175,7 @@ $$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + [C]_1\bullet G_
 
 where
 
-$$\underbrace{(\alpha+\sum_{i=1}^m a_iu_i(\tau))}_{[A]_1}\underbrace{(\beta +\sum_{i=1}^m a_iv_i(\tau))}_{[B]_2} =[\alpha]_1\bullet[\beta]_2 + \underbrace{\alpha\sum_{i=1}^m a_iv_i(\tau) + \beta\sum_{i=1}^m a_iu_i(\tau) + \sum_{i=1}^n a_iw_i(\tau) + h(\tau)t(\tau)}_{[C]_1}$$
+$$\underbrace{(\alpha+\sum_{i=1}^m a_iu_i(\tau))}_{[A]_1}\underbrace{(\beta +\sum_{i=1}^m a_iv_i(\tau))}_{[B]_2} =[\alpha]_1\bullet[\beta]_2 + \underbrace{\alpha\sum_{i=1}^m a_iv_i(\tau) + \beta\sum_{i=1}^m a_iu_i(\tau) + \sum_{i=1}^m a_iw_i(\tau) + h(\tau)t(\tau)}_{[C]_1}$$
 
 The prover can compute $[A]_1$ and $[B]_2$ without knowing $\tau$, $\alpha$, or $\beta$. Given the structured reference string (powers of $\tau$) and the elliptic curve points $([α]_1,[β]_2)$, the prover computes $[A]_1$ and $[B]_2$ as
 
@@ -192,7 +192,7 @@ However, it isn't currently possible to compute $[C]_1$ without knowing $\alpha$
 
 Instead, the trusted setup needs to precompute $m$ polynomials for the problematic $C$ term of the expanded QAP.
 
-$$\alpha\sum_{i=1}^m a_iv_i(\tau) + \beta\sum_{i=1}^m a_iu_i(\tau) + \sum_{i=1}^n a_iw_i(\tau)$$
+$$\alpha\sum_{i=1}^m a_iv_i(\tau) + \beta\sum_{i=1}^m a_iu_i(\tau) + \sum_{i=1}^m a_iw_i(\tau)$$
 
 With some algebraic manipulation, we combine the sum terms into a single sum:
 


### PR DESCRIPTION
I have
1. fixed one line where it said lagrange interpolation was done on x values `1,2,3,4` but it should be x=`1,2,3` as **n=3**
2. explained why trusted setup should only provide SRS for $h(x)t(x)$ of power upto **n-2**