### PR TITLE
Vector size fixed in multiplying matrix with vector

### DIFF
--- a/content/bulletproofs-zk/en/bulletproofs-zk.md
+++ b/content/bulletproofs-zk/en/bulletproofs-zk.md
@@ -34,7 +34,7 @@ a_1\\a_2\\a_3
 \end{matrix}
 $$
 
-In other words, multiplying an $n \times m$ matrix by an $n$ dimensional vector is the same as computing $n$ inner products. So if we can directly prove an inner product was computed correctly, then we don't need the additional steps of creating a Quadratic Arithmetic Program.
+In other words, multiplying an $n \times m$ matrix by an $m$ dimensional vector is the same as computing $n$ inner products. So if we can directly prove an inner product was computed correctly, then we don't need the additional steps of creating a Quadratic Arithmetic Program.
 
 Furthermore, Bulletproofs do not use [pairings](https://www.rareskills.io/post/bilinear-pairing) (only basic [elliptic curve addition](https://www.rareskills.io/post/elliptic-curve-addition)) and do not require a [trusted setup](https://www.rareskills.io/post/trusted-setup).
 

--- a/content/log-n-vector-commitment-proof/en/log-n-vector-commitment-proof.md
+++ b/content/log-n-vector-commitment-proof/en/log-n-vector-commitment-proof.md
@@ -155,8 +155,8 @@ Given $v = \langle\mathbf{a},\mathbf{b}\rangle$ and commitment $P = vQ+\langle\m
 1. The prover computes and sends to the verifier $(L, R)$ which are simply the off-diagonal terms of all the vectors concatenated together (see the animation above):
 
 $$\begin{align*}
-L &= (a_1b_2 + a_3b_4 + \dots a_{n-1}b_n)Q+(a_1G_2 + a_3G_4 + \dots a_{n-1}G_n)+(b_2H_1 + b_4H_3 + \dots b_nH_{n-1})\\
-R &= (a_2b_1 + a_4b_3 + \dots a_nb_{n-1})Q+(a_2G_1 + a_4G_3 + \dots a_nG_{n-1})+(b_1G_2 + b_3G_4 + \dots b_{n-1}G_n)
+L &= (a_1b_2 + a_3b_4 + \dots a_{n-1}b_n)Q+(a_1G_2 + a_3G_4 + \dots a_{n-1}G_n)+(b_1H_2 + b_3H_4 + \dots b_{n-1}H_n)\\
+R &= (a_2b_1 + a_4b_3 + \dots a_nb_{n-1})Q+(a_2G_1 + a_4G_3 + \dots a_nG_{n-1})+(b_2H_1 + b_4H_3 + \dots b_nH_{n-1})
 \end{align*}
 $$
 
@@ -167,7 +167,7 @@ $$
 $$
 \begin{align*}
 P' &= Lu^2+P+Ru^{-2}\\
-\mathbf{G}'&=\mathsf{fold}(\mathbf{G}, u)\\
+\mathbf{G}'&=\mathsf{fold}(\mathbf{G}, u^{-1})\\
 \mathbf{H}'&=\mathsf{fold}(\mathbf{H}, u^{-1})\\\\
 \end{align*}
 $$
@@ -176,7 +176,7 @@ $$
 $$
 \begin{align*}
 \mathbf{a}'&=\mathsf{fold}(\mathbf{a},u)\\
-\mathbf{b}'&=\mathsf{fold}(\mathbf{b},u^{-1})
+\mathbf{b}'&=\mathsf{fold}(\mathbf{b},u)
 \end{align*}
 $$
 


### PR DESCRIPTION
In the matrix `n * m`, `n` is row and `m` is column of matrix.
when multiplying two matrix e.g. `A * B`; the number of columns of first matrix (`A`) should be equal to number of rows of second matrix (`B`)

Suppose `A` is `n * m`, and `B` is `m * k`, then the `A * B` works
So, in the context the second vector size should be `m`. Actually if we want consider this vector as matrix it has `m * 1` size
