### PR TITLE
fix: incorrect result of elliptic curve point addition

### DIFF
--- a/content/elliptic-curve-addition/en/elliptic-curve-addition.md
+++ b/content/elliptic-curve-addition/en/elliptic-curve-addition.md
@@ -153,7 +153,7 @@ $$
 \begin{align*}
 \lambda &= \frac{y₂ - y₁}{x₂ - x₁} \\
 x₃ &= \lambda² - x₁ - x₂ \\
-y₃ &= \lambda(x₃ - x₁) - y₁
+y₃ &= \lambda(x₁ - x₃) - y₁
 \end{align*}
 $$
 


### PR DESCRIPTION
The current result of elliptic curve point addition is incorrect. The current result is y3 = λ (x3-x1) - y1, but the correct result should be: y3 = λ (x1-x3) - y1

Below is the proof:

Since (x3, y3) is the point negation of the point on the line of slope λ, (x3,-y3) is on that line.

Since (x1, y1) and (x3, -y3) are both on that line, λ = (-y3-y1) / (x3-x1),

==> (-y3-y1) = λ (x3-x1) 
==> (y3+y1) = λ (x1-x3) 
==> y3 = λ (x1-x3) - y1
