### PR TITLE
Prod

### DIFF
--- a/content/finite-fields/en/finite-fields.md
+++ b/content/finite-fields/en/finite-fields.md
@@ -46,7 +46,7 @@ The notation $\pmod p$ means *all* arithmetic is done modulo $p$. For example,
 
 $$a + b = c + d \pmod p$$
 
-Is equivalent (in Python or C) to `a + b % p == c + d % p`.
+Is equivalent (in Python or C) to `(a + b) % p == (c + d) % p`.
 
 Multiplication works similarly by multiplying the numbers together, then taking the modulus: 
 


### PR DESCRIPTION
because of operator precedence b % p and d % p are calculated first, and then added to a and c respectively. The correct Python or C equivalent would be (a + b) % p == (c + d) % p.

so the line should be: Is equivalent (in Python or C) to `(a + b) % p == (c + d) % p`.

Instead.