### PR TITLE
Fix Circom syntax error: `template main` → `component main` 

### DIFF
--- a/content/rank-1-constraint-system/en/rank-1-constraint-system.md
+++ b/content/rank-1-constraint-system/en/rank-1-constraint-system.md
@@ -1273,7 +1273,7 @@ template Multiply4() {
     out <== v1 * v2;
 }
 
-template main = Multiply4();
+component main = Multiply4();
 ```
 
 With everything we’ve discussed so far, the Circom output and the annotations should be self-explanatory.


### PR DESCRIPTION
This PR corrects a syntax error in the Circom code example at line 1276. 

Changed `template main = Multiply4();` to `component main = Multiply4();`. In Circom, `template is used to declare circuit definitions, while component is used to instantiate them. The entry point must be declared as a component instance, not a template. 