### PR TITLE
Fix notation inconsistencies in Groth16 tutorial

### DIFF
--- a/content/groth16/en/groth16.md
+++ b/content/groth16/en/groth16.md
@@ -266,7 +266,7 @@ $$\begin{align*}
 Note that only the computation of $[C]_1$ changed -- the prover only uses the $a_i$ and $\Psi_i$ terms $\ell + 1$ to $m$.
 
 The verifier computes the first $\ell$ terms of the sum:
-$$[X]_1=\sum_{i=1}^\ell a_i\Psi_i$$
+$$[X]_1=\sum_{i=1}^\ell a_i[\Psi_i]_1$$
 
 And the verification equation is:
 
@@ -279,21 +279,21 @@ The assumption in the equation above is that the prover is only using $\Psi_{\el
 
 For example, here is our current verification equation:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + \sum_{i=1}^\ell a_i\Psi_i +  [C]_1\bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + \sum_{i=1}^\ell a_i[\Psi_i]_1\bullet G_2 +  [C]_1\bullet G_2$$
 
 If we expand the $[C]_1$ term under the hood, we get the following:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (\sum_{i=1}^\ell a_i\Psi_i) \bullet G_2 + \underbrace{(\sum_{i=\ell+1}^m a_i[\Psi_i]_1 + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (\sum_{i=1}^\ell a_i[\Psi_i]_1) \bullet G_2 + \underbrace{(\sum_{i=\ell+1}^m a_i[\Psi_i]_1 + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
 
 Suppose for example and without loss of generality that $\mathbf{a} = [1,2,3,4,5]$ and $\ell=3$. In that case, the public part of the witness is $[1,2,3]$ and the private part is $[4,5]$.
 
 The final equation would be as follows:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+3\Psi_3)\bullet G_2 + \underbrace{(4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1[\Psi_1]_1+2[\Psi_2]_1+3[\Psi_3]_1)\bullet G_2 + \underbrace{(4[\Psi_4]_1 + 5[\Psi_5]_1  + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
 
 However, nothing stops the prover from creating an valid portion of the public witness as [1,2,0] and moving the zeroed out public portion to the private part of the computation as follows:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+\boxed{0\Psi_3})\bullet G_2 + \underbrace{(\boxed{3\Psi_3}+4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1[\Psi_1]_1+2[\Psi_2]_1+\boxed{0[\Psi_3]_1})\bullet G_2 + \underbrace{(\boxed{3[\Psi_3]_1}+4[\Psi_4]_1 + 5[\Psi_5]_1  + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
 
 The equation above is valid, but the witness does not necessarily satisfy the original constraints.
 
@@ -477,7 +477,7 @@ The verifier checks
 
 $$
 \begin{align*}
-[X]_1&=\sum_{i=1}^\ell a_i\Psi_i\\
+[X]_1&=\sum_{i=1}^\ell a_i[\Psi_i]_1\\
 [A]_1\bullet[B]_2 &\stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + [X]_1\bullet [\gamma]_2 + [C]_1\bullet [\delta]_2
 \end{align*}
 $$

--- a/content/groth16/en/groth16.md
+++ b/content/groth16/en/groth16.md
@@ -281,19 +281,19 @@ For example, here is our current verification equation:
 
 $$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + \sum_{i=1}^\ell a_i\Psi_i +  [C]_1\bullet G_2$$
 
-If we expand the C term under the hood, we get the following:
+If we expand the $[C]_1$ term under the hood, we get the following:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (\sum_{i=1}^\ell a_i\Psi_i) \bullet G_2 + \underbrace{(\sum_{i=\ell+1}^m a_i[\Psi_i]_1 + h(\tau)t(\tau))}_C \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (\sum_{i=1}^\ell a_i\Psi_i) \bullet G_2 + \underbrace{(\sum_{i=\ell+1}^m a_i[\Psi_i]_1 + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
 
 Suppose for example and without loss of generality that $\mathbf{a} = [1,2,3,4,5]$ and $\ell=3$. In that case, the public part of the witness is $[1,2,3]$ and the private part is $[4,5]$.
 
 The final equation would be as follows:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+3\Psi_3)\bullet G_2 + \underbrace{(4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_C \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+3\Psi_3)\bullet G_2 + \underbrace{(4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
 
 However, nothing stops the prover from creating an valid portion of the public witness as [1,2,0] and moving the zeroed out public portion to the private part of the computation as follows:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+\boxed{0\Psi_3})\bullet G_2 + \underbrace{(\boxed{3\Psi_3}+4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_C \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+\boxed{0\Psi_3})\bullet G_2 + \underbrace{(\boxed{3\Psi_3}+4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_{[C]_1} \bullet G_2$$
 
 The equation above is valid, but the witness does not necessarily satisfy the original constraints.
 

--- a/content/groth16/en/groth16.md
+++ b/content/groth16/en/groth16.md
@@ -279,7 +279,7 @@ The assumption in the equation above is that the prover is only using $\Psi_{\el
 
 For example, here is our current verification equation:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + \sum_{i=1}^\ell a_i[\Psi_i]_1\bullet G_2 +  [C]_1\bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (\sum_{i=1}^\ell a_i[\Psi_i]_1)\bullet G_2 +  [C]_1\bullet G_2$$
 
 If we expand the $[C]_1$ term under the hood, we get the following:
 

--- a/content/groth16/en/groth16.md
+++ b/content/groth16/en/groth16.md
@@ -273,7 +273,7 @@ And the verification equation is:
 $$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + [X]_1\bullet G_2 + [C]_1\bullet G_2$$
 
 ## Part 2: Separating the public inputs from the private inputs with $\gamma$ or $\delta$
-### Forging proofs by misuing $\Psi_i$ for $i\leq\ell$
+### Forging proofs by misusing $\Psi_i$ for $i\leq\ell$
 
 The assumption in the equation above is that the prover is only using $\Psi_{\ell+1}$ to $\Psi_m$ to compute $[C]_1$, but nothing stops a dishonest prover from using $\Psi_1$ to $\Psi_{\ell}$ to compute $[C]_1$, leading to a forged proof.
 
@@ -283,17 +283,17 @@ $$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + \sum_{i=1}^\ell
 
 If we expand the C term under the hood, we get the following:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + \sum_{i=1}^\ell a_i\Psi_i + \underbrace{(\sum_{i=\ell+1}^m a_i[\Psi_i]_1 + h(\tau)t(\tau))}_C \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (\sum_{i=1}^\ell a_i\Psi_i) \bullet G_2 + \underbrace{(\sum_{i=\ell+1}^m a_i[\Psi_i]_1 + h(\tau)t(\tau))}_C \bullet G_2$$
 
 Suppose for example and without loss of generality that $\mathbf{a} = [1,2,3,4,5]$ and $\ell=3$. In that case, the public part of the witness is $[1,2,3]$ and the private part is $[4,5]$.
 
 The final equation would be as follows:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+3\Psi_3)\bullet G2 + \underbrace{(4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_C \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+3\Psi_3)\bullet G_2 + \underbrace{(4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_C \bullet G_2$$
 
 However, nothing stops the prover from creating an valid portion of the public witness as [1,2,0] and moving the zeroed out public portion to the private part of the computation as follows:
 
-$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+\boxed{0\Psi_3})\bullet G2 + \underbrace{(\boxed{3\Psi_3}+4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_C \bullet G_2$$
+$$[A]_1\bullet[B]_2 \stackrel{?}= [\alpha]_1 \bullet [\beta]_2 + (1\Psi_1+2\Psi_2+\boxed{0\Psi_3})\bullet G_2 + \underbrace{(\boxed{3\Psi_3}+4\Psi_4 + 5\Psi_5  + h(\tau)t(\tau))}_C \bullet G_2$$
 
 The equation above is valid, but the witness does not necessarily satisfy the original constraints.
 


### PR DESCRIPTION
## Summary
This PR fixes several notation inconsistencies in the Groth16 tutorial to improve mathematical rigor and type safety.

## Changes Made

### 1. Fixed typos and formatting
- Corrected "misuing" → "misusing" in section heading
- Fixed "G2" → "G_2" for consistent mathematical notation
- Added parentheses for clarity in pairing operations

### 2. Improved notation consistency for C term
- Changed underbrace labels from `C` to `[C]_1` throughout
- Updated text references from "C term" to "$[C]_1$ term"
- Ensures clear distinction between scalar and point notation

### 3. Fixed scalar vs point notation
- Corrected all instances where scalar `Psi_i` was used instead of point `[Psi_i]_1`
- Applied fixes to lines 269, 282, 286, 292, 296, and 480
- Ensures type correctness: `Psi_i` (scalar) vs `[Psi_i]_1` (point in G_1)

### 4. Added missing parentheses
- Fixed line 282 to ensure pairing operation applies to entire sum
- Makes equation consistent with surrounding context

