### PR TITLE
some minor typos

### DIFF
--- a/content/elliptic-curves-finite-fields/en/elliptic-curves-finite-fields.md
+++ b/content/elliptic-curves-finite-fields/en/elliptic-curves-finite-fields.md
@@ -383,7 +383,7 @@ assert eq(multiply(G1, x), multiply(G1, x + curve_order))
 assert eq(multiply(G1, x), multiply(G1, x + field_modulus))
 ```
 
-The implication of this is that `(x + y) mod curve_order == xG + yG`.
+The implication of this is that `((x + y) mod curve_order)G == xG + yG`.
 
 ```python
 x = 2 ** 300 + 21

--- a/content/finite-fields/en/finite-fields.md
+++ b/content/finite-fields/en/finite-fields.md
@@ -195,7 +195,7 @@ assert (5 * 7) % p == 1
 
 **Exercise:** Find the multiplicative inverse of 3 modulo 5. There are only 5 possibilities, so try all of them and see which ones work.
 
-**Exercise:** What is the multiplicative inverse of 50 in the finite field $p = 51$? You do not need Python to compute this, see the principles described in “General rules of multiplicative inverses.”
+**Exercise:** What is the multiplicative inverse of 50 in the finite field $p = 53$? You do not need Python to compute this, see the principles described in “General rules of multiplicative inverses.”
 
 **Exercise:** Use Python to compute the multiplicative inverse of 288 in the finite field of `p = 311`. You can check your work by validating that `(288 * answer) % 311 == 1`.
 
@@ -647,7 +647,7 @@ There are no roots because $\sqrt{5}$ cannot be represented in a finite field mo
 
 ### Limitations in arithmetic circuits for ZK Proofs
 
-If we wish to write an arithmetic circuit to show "I know the root of the polynomial $y = x² − 5$" using an arithmetic circuit over a finite field, then we may run into the issue of not being able to encode $\sqrt{5}$. That is, over real numbers, $y = x² − 5$ has a root of $\sqrt{5}$, but this cannot be expressed in some finite fields. Depending on $p$, the arithmetic circuit `x² === 5` may have no no satisfying witness.
+If we wish to write an arithmetic circuit to show "I know the root of the polynomial $y = x² − 5$" using an arithmetic circuit over a finite field, then we may run into the issue of not being able to encode $\sqrt{5}$. That is, over real numbers, $y = x² − 5$ has a root of $\sqrt{5}$, but this cannot be expressed in some finite fields. Depending on $p$, the arithmetic circuit `x² === 5` may have no satisfying witness.
 
 ### Polynomials in finite fields with Python
 

--- a/content/groth16/en/groth16.md
+++ b/content/groth16/en/groth16.md
@@ -109,7 +109,7 @@ $$[A]_1 \bullet [B]_2 \stackrel{?}= [D]_{12} + [C]_1\bullet G_2$$
 
 Here, $[D]_{12}$ is an element from $G_{12}$ and has an unknown discrete logarithm.
 
-We now show that it is impossible for a verifier to provide a solution $([A]_1, [B]_2, [C]_1)$ to this equation, without knowing the discrete logarithm of $[D]_{12}$.
+We now show that it is impossible for a prover to provide a solution $([A]_1, [B]_2, [C]_1)$ to this equation, without knowing the discrete logarithm of $[D]_{12}$.
 
 #### Attack 1: Forging A and B and deriving C
 Suppose the prover randomly selects $a’$ and $b’$ to produce $[A]₁$ and $[B]₂$ and tries to derive a value $[C’]$ that is compatible with the verifier’s formula.

--- a/content/hello-world-circom/en/hello-world-circom.md
+++ b/content/hello-world-circom/en/hello-world-circom.md
@@ -331,7 +331,7 @@ The output is the computed witness as a `witness.wtns` file.
 <aside>
 💡
 
-If we had passed values that did not honor the constraint, `a*b === c`, e.g. `a=1`, `b=2`, `c=3`, `witness_calculator.js` would throw an error. 
+If we had passed values that did not honor the constraint, `a*b === c`, e.g. `a=1`, `b=2`, `c=2`, `witness_calculator.js` would throw an error. 
 
 </aside>
 

--- a/content/r1cs-to-qap/en/r1cs-to-qap.md
+++ b/content/r1cs-to-qap/en/r1cs-to-qap.md
@@ -24,7 +24,7 @@ First, we define our matrices $\mathbf{L}$, $\mathbf{R}$, and $\mathbf{O}$ as fo
 ```python
 import numpy as np
 
-# 1, out, x, y, v1, v2, v3
+# 1, z, x, y, v1, v2, v3
 L = np.array([
     [0, 0, 1, 0, 0, 0, 0],
     [0, 0, 0, 0, 1, 0, 0],
@@ -124,9 +124,9 @@ y = GF(-2 + 79) # we are using 79 as the field size, so 79 - 2 is -2
 v1 = x * x
 v2 = v1 * v1         # x^4
 v3 = GF(-5 + 79)*y * y
-out = v3*v1 + v2    # -5y^2 * x^2
+z = v3*v1 + v2    # -5y^2 * x^2
 
-witness = GF(np.array([1, out, x, y, v1, v2, v3]))
+witness = GF(np.array([1, z, x, y, v1, v2, v3]))
 
 assert all(np.equal(np.matmul(L_galois, witness) * np.matmul(R_galois, witness), np.matmul(O_galois, witness))), "not equal"
 ```


### PR DESCRIPTION
- In finite-fields: 51 is not a prime, so p=51 is not a finite field
- In r1cs-to-qap: there is an inconsistency in the naming of the output variable (sometimes it was `z`, and sometimes `out`)
- other minor corrections