### PR TITLE
Minor fixes

### DIFF
--- a/content/elliptic-curve-qap/en/elliptic-curve-qap.md
+++ b/content/elliptic-curve-qap/en/elliptic-curve-qap.md
@@ -138,7 +138,7 @@ $$
 \begin{align*}
 [A]_1 &=\sum_{i=1}^4 a_iu_i(\tau) = \langle[u_{2a}, u_{1a}, u_{0a}],[\Omega_2, \Omega_1, G_1]\rangle\\
 [B]_2 &=\sum_{i=1}^4 a_iv_i(\tau) = \langle[v_{2a}, v_{1a}, v_{0a}],[\Theta_2, \Theta_1, G_2]\rangle\\
-[C]_1 &=\sum_{i=1}^4 a_iw_i(\tau) = \langle[v_{2a}, v_{1a}, v_{0a}],[\Omega_2, \Omega_1, G_1]\rangle \\
+[C]_1 &=\sum_{i=1}^4 a_iw_i(\tau) = \langle[w_{2a}, w_{1a}, w_{0a}],[\Omega_2, \Omega_1, G_1]\rangle \\
 \end{align*}
 $$
 

--- a/content/elliptic-curve-qap/en/elliptic-curve-qap.md
+++ b/content/elliptic-curve-qap/en/elliptic-curve-qap.md
@@ -75,7 +75,7 @@ $$
 ### The degrees of the polynomials in the QAP with respect to the size of the R1CS
 A couple observations about the degrees of the polynomials in the general case:
 - The degree of $u(x)$ and $v(x)$ could be as high as $n - 1$ because they interpolate $n$ points, where $n$ is the number of rows in the R1CS.
-- The degree of $w(x)$ could be as low as 0 if the sum of the polynomials $\sum_{i=0}^m a_iw_i(x)$ adds up to the zero polynomial, that is, the coefficients additively cancel each other out.
+- The degree of $w(x)$ could be as low as 0 if the sum of the polynomials $\sum_{i=1}^m a_iw_i(x)$ adds up to the zero polynomial, that is, the coefficients additively cancel each other out.
 - $t(x)$ is degree $n$ by definition.
 - Multiplying polynomials adds their degrees together, and dividing polynomials subtracts their degrees.
 

--- a/content/rank-1-constraint-system/en/rank-1-constraint-system.md
+++ b/content/rank-1-constraint-system/en/rank-1-constraint-system.md
@@ -1265,7 +1265,7 @@ template Multiply4() {
     signal v1;
     signal v2;
     
-    signal out;
+    signal output out;
     
     v1 <== x * y;
     v2 <== z * u;


### PR DESCRIPTION
The change in `rank-1-constraint-system.md` corrects an inconsistency: after the Multiply4 example, the Circom output screenshot shows `public outputs: 1`, which is only accurate if out is defined as an `output` signal.

The updates in `elliptic-curve-qap.md` are for minor typos.