### PR TITLE
Fix spGteTwo condition in zkvm

### DIFF
--- a/content/zkvm/en/zkvm.md
+++ b/content/zkvm/en/zkvm.md
@@ -127,7 +127,7 @@ template ShouldCopy(i, bits) {
   signal spEqOne;
   signal spGteTwo;
   spEqOne <== IsEqual()([sp, 1]);
-  spGteTwo <== 1 - spEqOne * spEqZero;
+  spGteTwo <== (1 - spEqOne) * (1 - spEqZero);
   
   // the current column is 1 or more 
   // below the stack pointer


### PR DESCRIPTION
The `spGteTwo` computation is incorrect in [zk vm](https://rareskills.io/post/zkvm).

Since `spEqOne` (sp == 1) and `spEqZero` (sp == 0) can't be both true at the same time, `spEqOne * spEqZero` is guaranteed to be 0 and the current computation of `spGteTwo` is guaranteed to be `1 - 0 = 1`.

Instead `spGteTwo` should be computed in the same way it is in [zk stack](https://rareskills.io/post/zk-stack), namely as `(1 - spEqOne) * (1 - spEqZero)`.