### PR TITLE
Avoid sp underflow due to pop in zk-stack

### DIFF
--- a/content/zk-stack/en/zk-stack.md
+++ b/content/zk-stack/en/zk-stack.md
@@ -429,6 +429,8 @@ template CopyStack(m) {
 The following code is the final implementation of our stack, which combines all the components together. Since we have already shown the components for `ShouldCopy` and `CopyStack`, the reader can jump down to the final component `StackBuilder`. The previous components are from the earlier sections. We put it into a single file so the reader can conveniently copy and paste this into [zkrepl](https://zkrepl.dev) to test it:
 
 ```jsx
+pragma circom 2.1.6;
+
 include "circomlib/comparators.circom";
 include "circomlib/gates.circom";
 
@@ -591,6 +593,7 @@ template StackBuilder(n) {
   component EqPush[n];
   component EqNop[n];
   component EqPop[n];
+  component PopGuard[n];
 
   component eqSP[n][n];
   signal eqSPAndIsPush[n][n];
@@ -620,6 +623,11 @@ template StackBuilder(n) {
     EqPop[i].in[0] <== instr[2 * i];
     EqPop[i].in[1] <== POP;
     metaTable[i][IS_POP] <== EqPop[i].out;
+
+    // prevent POP when stack is empty
+    PopGuard[i] = IsZero();
+    PopGuard[i].in <== sp[i];
+    metaTable[i][IS_POP] * PopGuard[i].out === 0;
 
     // get the instruction argument
     metaTable[i][ARG] <== instr[2 * i + 1];


### PR DESCRIPTION
In the [zk-stack](https://rareskills.io/post/zk-stack) example, `sp` is not protected against underflow. The only somewhat related condition is:

```
  // first instruction must be PUSH or NOP
  (instr[0] - PUSH) * (instr[0] - NOP) === 0;
```

But this only protects it for underflow in the specific case of POP being the first instruction. Instead, the general condition should be that POP is not allowed whenever `sp == 0`.

To show the underflow, run the stack circuit on zkREPL using the following input, i.e. PUSH + POP + POP:
```
/* INPUT = {
  "instr": [1, 16, 2, 0, 2, 0]
} */
```

The output shows the underflow for SP:
```
Output: 
sp[0] = 0
sp[1] = 1
sp[2] = 0
sp[3] = 21888242871839275222246405745257275088548364400416034343698204186575808495616
stack[0][0] = 16
stack[0][1] = 0
stack[0][2] = 0
stack[1][0] = 0
stack[1][1] = 0
stack[1][2] = 0
stack[2][0] = 0
stack[2][1] = 0
stack[2][2] = 0
```