### PR TITLE
Fix Poseidon loop index typo

### DIFF
--- a/content/zk-friendly-hash/en/zk-friendly-hash.md
+++ b/content/zk-friendly-hash/en/zk-friendly-hash.md
@@ -110,7 +110,7 @@ template Example(n) {
   component hash = Poseidon(n);
 
   for (var i = 0; i < n; i++) {
-    hash.inputs[0] <== in[i];
+    hash.inputs[i] <== in[i];
   }
   out <== hash.out;
 }


### PR DESCRIPTION
`hash.inputs[0] <== in[i]` always writes to index 0. Should be `hash.inputs[i] <== in[i]`.