### PR TITLE
Fix the template n value for permutation argument example

### DIFF
--- a/content/permutation-argument/en/permutation-argument.md
+++ b/content/permutation-argument/en/permutation-argument.md
@@ -118,6 +118,7 @@ The circuit below takes two lists and checks if they are permutations of each ot
 Thus, the final entry `prodA[n - 1]` holds the evaluation of the polynomial at `r`. Here, `r` is `hash.out`, which is the Poseidon hash of all the entries of arrays `a` and `b`.
 
 ```jsx
+pragma circom 2.1.6;
 
 include "circomlib/poseidon.circom";
 
@@ -148,7 +149,7 @@ template IsPermutation(n) {
   prodA[n - 1] === prodB[n - 1];
 }
 
-component main = IsPermutation(3);
+component main = IsPermutation(6);
 
 /* INPUT = {
   "a": [1,2,3,4,5,6],


### PR DESCRIPTION
In the example code, `n` represents the length of the input lists. As the input lists are of length 6, the argument to `IsPermutation` must be the same.

Currently the following error comes up in zkREPL due to using lists of length 6 and n=3:

```
fail: 
Too many values for input signal a
```

Also added pragma to avoid warning:
```
stderr: 
warning[P1004]: File "main.circom" does not include pragma version. Assuming pragma version (2, 1, 6)
```