### PR TITLE
Fix multiple content errors across ZK articles

### DIFF
--- a/content/compute-then-constrain/en/compute-then-constrain.md
+++ b/content/compute-then-constrain/en/compute-then-constrain.md
@@ -243,7 +243,7 @@ Thus, we really want subcircuits to *indicate* that a certain condition holds (i
 
 ```jsx
 // at least one of the two signals is not zero
-x_eq_42 * x_lt_16 === 1;
+(1 - x_eq_42) * (1 - x_lt_16) === 0
 ```
 
 To create an *indicator* that `x` equals 42, we want to know if the value `x - 42` is precisely zero or not.

--- a/content/groth16/en/groth16.md
+++ b/content/groth16/en/groth16.md
@@ -109,7 +109,7 @@ $$[A]_1 \bullet [B]_2 \stackrel{?}= [D]_{12} + [C]_1\bullet G_2$$
 
 Here, $[D]_{12}$ is an element from $G_{12}$ and has an unknown discrete logarithm.
 
-We now show that it is impossible for a verifier to provide a solution $([A]_1, [B]_2, [C]_1)$ to this equation, without knowing the discrete logarithm of $[D]_{12}$.
+We now show that it is impossible for a prover to provide a solution $([A]_1, [B]_2, [C]_1)$ to this equation, without knowing the discrete logarithm of $[D]_{12}$.
 
 #### Attack 1: Forging A and B and deriving C
 Suppose the prover randomly selects $a’$ and $b’$ to produce $[A]₁$ and $[B]₂$ and tries to derive a value $[C’]$ that is compatible with the verifier’s formula.

--- a/content/log-n-vector-commitment-proof/en/log-n-vector-commitment-proof.md
+++ b/content/log-n-vector-commitment-proof/en/log-n-vector-commitment-proof.md
@@ -46,7 +46,7 @@ The prover and verifier then engage in the following algorithm below. The argume
 
 In the algorithm description below $n$ is the length of the vectors in the input, which are all of the same length.
 
-#### $\texttt{prove_commitments_log}(P, \mathbf{G}, | \mathbf{a})$
+#### $\texttt{prove\_commitments\_log}(P, \mathbf{G}, | \mathbf{a})$
 ##### Case 1: $n = 1$
 
 1. The prover sends $a$ and the verifier checks that $aG \stackrel{?}= P$ and the algorithm ends.
@@ -68,7 +68,7 @@ P' &= Lu^2+P+Ru^{-2}
 $$
 4. The prover computes
 $$\mathbf{a}'=\mathsf{fold}(\mathbf{a},u)$$
-5. $\texttt{prove_commitments_log}(P', \mathbf{G}', \mathbf{a}')$
+5. $\texttt{prove\_commitments\_log}(P', \mathbf{G}', \mathbf{a}')$
 
 ### Commentary on the algorithm
 The prover is recursively proving that, given values $P$ and $\mathbf{G}$, they know the $\mathbf{a}$ such that $P=\langle\mathbf{a},\mathbf{G}\rangle$. Both parties recursively fold $\mathbf{G}$ until it is a single point, and the prover recursively folds $\mathbf{a}$ until it is a single point.
@@ -140,7 +140,7 @@ We show the algorithm in the animation below:
 ## The algorithm
 Given $v = \langle\mathbf{a},\mathbf{b}\rangle$ and commitment $P = vQ+\langle\mathbf{a},\mathbf{G}\rangle + \langle\mathbf{b},\mathbf{H}\rangle$ we wish to prove that $P$ is committed as claimed. That is, $v$, $\mathbf{a}$, and $\mathbf{b}$ are committed to $P$ and $\langle\mathbf{a},\mathbf{b}\rangle=v$.
 
-#### $\texttt{prove_commitments_log}(P, \mathbf{G}, \mathbf{H},Q, |\mathbf{a}, \mathbf{b})$
+#### $\texttt{prove\_commitments\_log}(P, \mathbf{G}, \mathbf{H},Q, |\mathbf{a}, \mathbf{b})$
 ##### Case 1: $n = 1$
 
 1. The prover sends $(a,b)$ and the verifier checks that $P \stackrel{?}= aG + bH + abQ$. The algorithm ends.
@@ -168,7 +168,7 @@ $$
 \mathbf{b}'&=\mathsf{fold}(\mathbf{b},u^{-1})
 \end{align*}
 $$
-5. $\texttt{prove_commitments_log}(P', G', H', \mathbf{a}', \mathbf{b}')$
+5. $\texttt{prove\_commitments\_log}(P', G', H', \mathbf{a}', \mathbf{b}')$
 
 The following exercises can be found in our [ZK Bulletproofs GitHub Repo](https://github.com/RareSkills/ZK-bulletproofs/tree/main):
 

--- a/content/outer-product-inner-product/en/outer-product-inner-product.md
+++ b/content/outer-product-inner-product/en/outer-product-inner-product.md
@@ -199,7 +199,7 @@ $$
 
 Under the hood this is:
 $$
-\underbrace{a_1G_2}_L + \underbrace{u(a_1G_1 + a_2G_2)}_{uA} + \underbrace{a_2u G_1}_{u^2R} = \underbrace{(a_1 + u a_2)}_{a'}(u G_1 + G_2)
+\underbrace{a_1G_2}_L + \underbrace{u(a_1G_1 + a_2G_2)}_{uA} + \underbrace{a_2u^2 G_1}_{u^2R} = \underbrace{(a_1 + u a_2)}_{a'}(u G_1 + G_2)
 $$
 
 which is identically correct if the prover correctly computed $a'$, $L$, and $R$.

--- a/content/outer-product-inner-product/en/outer-product-inner-product.md
+++ b/content/outer-product-inner-product/en/outer-product-inner-product.md
@@ -204,7 +204,7 @@ $$
 
 which is identically correct if the prover correctly computed $a'$, $L$, and $R$.
 
-Note that the verifier applied $u$ to $G_2$ whereas the prover applied $u$ to $a_1$. This causes the terms of the original inner product to be the linear coefficients of the resulting polynomial.
+Note that the verifier applied $u$ to $G_1$ whereas the prover applied $u$ to $a_2$. This causes the terms of the original inner product to be the linear coefficients of the resulting polynomial.
 
 The fact that $L$ and $R$ are separated by $u^2$, which the verifier controls, prevents a malicious prover from doing the attack described earlier. That is, the prover cannot shift value from $R$ to $L$ because the value they shift must be scaled by $u^2$, but the prover must send $L$ and $R$ before they receive $u$.
 

--- a/content/zk-friendly-hash/en/zk-friendly-hash.md
+++ b/content/zk-friendly-hash/en/zk-friendly-hash.md
@@ -110,7 +110,7 @@ template Example(n) {
   component hash = Poseidon(n);
 
   for (var i = 0; i < n; i++) {
-    hash.inputs[0] <== in[i];
+    hash.inputs[i] <== in[i];
   }
   out <== hash.out;
 }


### PR DESCRIPTION
Fixed math, logic, and formatting errors across five articles.

**zk-friendly-hash.md**
- Fixed loop index in Poseidon example (`inputs[0]` -> `inputs[i]`)

**groth16.md**
- Updated wording from "verifier" to "prover"

**compute-then-constrain.md**
- Fixed incorrect constraint for "at least one is true"
  `x_eq_42 * x_lt_16 === 1` -> `(1 - x_eq_42) * (1 - x_lt_16) === 0`)

**outer-product-inner-product.md**
- Updated u²R expansion (`a₂uG₁` -> `a₂u²G₁`)
- Updated swapped variable description (`G₂, a₁` -> `G₁, a₂`)

**log-n-vector-commitment-proof.md**
- Fixed broken LaTeX in `prove_commitments_log` headings
  (Added `\` before every `_`)