### PR TITLE
fix: code snippet logical correctness and syntax

### DIFF
--- a/content/elliptic-curves-finite-fields/en/elliptic-curves-finite-fields.md
+++ b/content/elliptic-curves-finite-fields/en/elliptic-curves-finite-fields.md
@@ -420,7 +420,7 @@ For example, we cannot do the following using regular integers.
 
 ```python
 # this throws an exception
-eq(add(multiply(G1, 5 / 2), multiply(G1, 1 / 2), multiply(G1, 3)
+eq(multiply(G1, 5 / 2), add(multiply(G1, 1 / 2), multiply(G1, 2)))
 ```
 However, in a finite field, 1/2 can be meaningfully computed as the multiplicative inverse of 2. Therefore, 5 / 2 can be encoded as $5 \cdot \mathsf{inv}(2)$.
 


### PR DESCRIPTION
The flow of thought was explaining why we need to encode division separately for it to be valid in a finite field. The code snippet below is meant to demonstrate why encoding is needed despite the ***logical correctness** of the equality....

```python
# this throws an exception
eq(add(multiply(G1, 5 / 2), multiply(G1, 1 / 2), multiply(G1, 3)
```

I've fixed the **logical correctness** — `5/2 == 1/2 + 2` NOT `1/2 + 3`, re-arranged the `add` function call to the appropriate place, and added the correct number of parentheses
```python
# this throws an exception
eq(multiply(G1, 5 / 2), add(multiply(G1, 1 / 2), multiply(G1, 2)))
```