### PR TITLE
Fix range issues in factorial and Fibonacci code

### DIFF
--- a/content/stateful-zk/en/stateful-zk.md
+++ b/content/stateful-zk/en/stateful-zk.md
@@ -86,15 +86,15 @@ template factorial(n) {
 
   // ensure that in < n
   signal inLTn;
-  inLTn <== LessThan(252)([in, n]);
+  inLTn <== LessThan(252)([in, n+1]);
   inLTn === 1;
   
   // select the factorial of interest
-  component mux = Multiplexer(1, n);
+  component mux = Multiplexer(1, n+1);
   mux.sel <== in;
 
   // assign factorials into the multiplexer
-  for (var i = 0; i < n; i++) {
+  for (var i = 0; i <= n; i++) {
     mux.inp[i][0] <== factorials[i];
   }
 
@@ -160,27 +160,27 @@ template Fibonacci(n) {
   // 0 to n
   signal fib[n + 1];
 
-  // compute the factorials
-  fib[0] <== 1;
+  // compute the fibonacci sequence until the n-th element
+  fib[0] <== 0;
   fib[1] <== 1;
   
-  for (var i = 2; i < n; i++) {
+  for (var i = 2; i <= n; i++) {
     fib[i] <== fib[i - 1] + fib[i - 2];
   }
 
   // ensure that in < n
   signal inLTn;
-  inLTn <== LessThan(252)([in, n]);
+  inLTn <== LessThan(252)([in, n+1]);
   inLTn === 1;
 
   // select the fibonacci number 
   // of interest
-  component mux = Multiplexer(1, n);
+  component mux = Multiplexer(1, n+1);
   mux.sel <== in;
 
   // assign Fibonacci into
   // the Quin Selector
-  for (var i = 0; i < n; i++) {
+  for (var i = 0; i <= n; i++) {
     mux.inp[i][0] <== fib[i];
   }
 


### PR DESCRIPTION
The two examples showcasing Fibonacci sequence and Factorial computation both don't actually support `user input = n` but only `n-1`. If user tries to compute the `n-th` fibonacci sequence's element or the factorial of `n` this will violate the constraint `inLTn <== LessThan(252)([in, n]);`

The computation happens but `Fib[99]` or `factorials[100]` are just dead code that never gets executed.

**Solution**: The computation for loop's index must accept n as an element (`i<=n`), `LessThan()` and `Multiplexer()` upper bound must be incremented by 1 (`n+1`) and  the `n-th` element in the for loop that assigns the sequences values to the multiplexer (`i<=n`) has to be included.

Also changed `Fib[0] = 1 `to `Fib[0] = 0` for definition correctness and fixed a typo in the comment of fibonacci, probably a copy-paste oversight from factorial to Fibonacci code.

